### PR TITLE
Top level info file changes for hdfs healing mode

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFile.cc
+++ b/src/XrdFileCache/XrdFileCacheFile.cc
@@ -99,12 +99,10 @@ File::~File()
    if (m_infoFile)
    {
       m_syncStatusMutex.Lock();
-      if ((! m_writes_during_sync.empty()) || m_non_flushed_cnt > 0)
-      {
-         Sync();
-         m_non_flushed_cnt = 0;
-      }
+      bool need_sync = (!m_writes_during_sync.empty()) || m_non_flushed_cnt > 0;
       m_syncStatusMutex.UnLock();
+      if (need_sync)
+         Sync();
 
       // write statistics in *cinfo file
       AppendIOStatToFileInfo();

--- a/src/XrdFileCache/XrdFileCacheFile.cc
+++ b/src/XrdFileCache/XrdFileCacheFile.cc
@@ -105,6 +105,7 @@ File::~File()
          Sync();
 
       // write statistics in *cinfo file
+      m_cfi.WriteHeader(m_infoFile);
       AppendIOStatToFileInfo();
       m_infoFile->Fsync();
 
@@ -146,11 +147,11 @@ bool File::ioActive()
    TRACEF(Debug, "File::Initiate close start");
 
    m_stateCond.Lock();
-   if (m_prefetchState != kStopped) {
+   if (m_prefetchState != kStopped)
+   {
       m_prefetchState = kStopped;
       cache()->DeRegisterPrefetchFile(this);
    }
-
    m_stateCond.UnLock();
 
    // remove failed blocks and check if map is empty
@@ -182,11 +183,13 @@ bool File::ioActive()
    bool blockMapEmpty =  m_block_map.empty();
    m_downloadCond.UnLock();
 
-   if ( blockMapEmpty)
+   if (blockMapEmpty)
    {
       // file is not active when block map is empty and sync is done
       XrdSysMutexHelper _lck(&m_syncStatusMutex);
-      if (m_in_sync == false) {
+      if ( ! m_in_sync)
+      {
+         m_in_sync = true;
          return false;
       }
    }
@@ -698,13 +701,10 @@ void File::WriteBlockToDisk(Block* b)
    TRACEF(Dump, "File::WriteToDisk() success set bit for block " <<  b->m_offset << " size " <<  size);
    int pfIdx =  (b->m_offset - m_offset)/m_cfi.GetBufferSize();
 
-   m_downloadCond.Lock();
-   assert((m_cfi.TestBit(pfIdx) == false) && "Block not yet fetched.");
-   m_cfi.SetBitFetched(pfIdx);
-   m_downloadCond.UnLock();
-
    {
       XrdSysCondVarHelper _lck(m_downloadCond);
+
+      m_cfi.SetBitFetched(pfIdx);
       // clLog()->Dump(XrdCl::AppMsg, "File::WriteToDisk() dec_ref_count %d %s", pfIdx, lPath());
       dec_ref_count(b);
    }
@@ -722,7 +722,7 @@ void File::WriteBlockToDisk(Block* b)
       {
          m_cfi.SetBitWriteCalled(pfIdx);
          ++m_non_flushed_cnt;
-         if (m_non_flushed_cnt >= 100 )
+         if (m_non_flushed_cnt >= 100)
          {
             schedule_sync     = true;
             m_in_sync         = true;
@@ -741,9 +741,12 @@ void File::WriteBlockToDisk(Block* b)
 
 void File::Sync()
 {
-   TRACEF( Dump, "File::Sync()");
+   TRACEF(Dump, "File::Sync()");
    m_output->Fsync();
+
    m_cfi.WriteHeader(m_infoFile);
+   m_infoFile->Fsync();
+
    int written_while_in_sync;
    {
       XrdSysMutexHelper _lck(&m_syncStatusMutex);
@@ -756,9 +759,6 @@ void File::Sync()
       m_in_sync = false;
    }
    TRACEF(Dump, "File::Sync() "<< written_while_in_sync  << " blocks written during sync.");
-  
-   m_cfi.WriteHeader(m_infoFile);
-   m_infoFile->Fsync();
 }
 
 //------------------------------------------------------------------------------
@@ -779,7 +779,7 @@ void File::dec_ref_count(Block* b)
    assert(b->m_refcnt >= 0);
 
    //AMT ... this is ugly, ... File::Read() can decrease ref count before waiting to be , prefetch starts with refcnt 0
-   if ( b->m_refcnt == 0 && b->is_finished())
+   if (b->m_refcnt == 0 && b->is_finished())
    {
       free_block(b);
    }
@@ -789,15 +789,15 @@ void File::free_block(Block* b)
 {
    int i = b->m_offset/BufferSize();
    TRACEF(Dump, "File::free_block block " << b << "  idx =  " <<  i);
-   delete m_block_map[i];
    size_t ret = m_block_map.erase(i);
    if (ret != 1)
    {
       // assert might be a better option than a warning
-      TRACEF(Warning, "File::OnBlockZeroRefCount did not erase " <<  i  << " from map");
+      TRACEF(Error, "File::free_block did not erase " <<  i  << " from map");
    }
    else
    {
+      delete b;
       cache()->RAMBlockReleased();
    }
 

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -184,6 +184,8 @@ int IOFileBlock::initLocalStat()
    // if there is no local info file, try to read from clinet and then save stat into a new *cinfo file
    if (res)
    {
+      if (m_infoFile) delete m_infoFile;
+
       res = GetInput()->Fstat(tmpStat);
       TRACEIO(Debug, "IOFileBlock::initCachedStat  get stat from client res= " << res << "size = " << tmpStat.st_size);
       if (res == 0)

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -169,7 +169,7 @@ int IOFileBlock::initLocalStat()
    if (m_cache.GetOss()->Stat(path.c_str(), &tmpStat) == XrdOssOK)
    {
       m_infoFile = m_cache.GetOss()->newFile(m_cache.RefConfiguration().m_username.c_str()); 
-      if (m_infoFile->Open(path.c_str(), O_RDONLY, 0600, myEnv) == XrdOssOK)
+      if (m_infoFile->Open(path.c_str(), O_RDWR, 0600, myEnv) == XrdOssOK)
       {
          Info info(m_cache.GetTrace());
          if (info.Read(m_infoFile, path))

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -196,6 +196,8 @@ int IOFileBlock::initLocalStat()
                // This is writing the top-level cinfo
                // The info file is used to get file size on defer open
                // don't initalize buffer, it does not hold useful information in this case
+               m_info.SetBufferSize(m_cache.RefConfiguration().m_bufferSize);
+               m_info.DisableDownloadStatus();
                m_info.SetFileSize(tmpStat.st_size);
                m_info.WriteHeader(m_infoFile, path);
                m_infoFile->Fsync();
@@ -214,7 +216,6 @@ int IOFileBlock::initLocalStat()
 
    if (res == 0) 
    {
-      std::cerr << "local stat created \n";
       m_localStat = new struct stat;
       memcpy(m_localStat, &tmpStat, sizeof(struct stat));
    }

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
@@ -74,7 +74,9 @@ namespace XrdFileCache
          long long                  m_blocksize; //!< size of file-block
          std::map<int, File*>       m_blocks;    //!< map of created blocks
          XrdSysMutex                m_mutex;     //!< map mutex
-         struct stat               *m_localStat; 
+         struct stat               *m_localStat;
+         Info                       m_info; 
+         XrdOssDF*                  m_infoFile;
 
          void GetBlockSizeFromPath();
          int initLocalStat();

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
@@ -81,6 +81,7 @@ namespace XrdFileCache
          void GetBlockSizeFromPath();
          int initLocalStat();
          File* newBlockFile(long long off, int blocksize);
+         void  CloseInfoFile();
    };
 }
 

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -103,6 +103,7 @@ Info::Info(XrdOucTrace* trace, bool prefetchBuffer) :
    m_version(1),
    m_bufferSize(-1),
    m_hasPrefetchBuffer(prefetchBuffer),
+   m_fileSize(0),
    m_sizeInBits(0),
    m_buff_fetched(0), m_buff_write_called(0), m_buff_prefetch(0),
    m_accessCnt(0),
@@ -195,10 +196,7 @@ bool Info::Read(XrdOssDF* fp, const std::string &fname)
 int Info::GetHeaderSize() const
 {
    // version + buffersize + file-size + download-status-array
-    if (m_bufferSize > 0 )
-        return sizeof(int) + sizeof(long long) + sizeof(long long) + GetSizeInBytes();
-    else 
-        return sizeof(int) + sizeof(long long) + sizeof(long long);
+   return sizeof(int) + sizeof(long long) + sizeof(long long) + GetSizeInBytes();
 }
 
 //------------------------------------------------------------------------------

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -176,14 +176,11 @@ bool Info::Read(XrdOssDF* fp, const std::string &fname)
    SetFileSize(fs);
 
    if (r.Read(m_buff_fetched, GetSizeInBytes())) return false;
-   assert (off == GetHeaderSize());
 
    memcpy(m_buff_write_called, m_buff_fetched, GetSizeInBytes());
    m_complete = ! IsAnythingEmptyInRng(0, m_sizeInBits);
 
-   // MT-XXXX it sucks to have this here! Unless it is written out in WriteHeader().
-   // Now hacking it to set access count to 0 on failure.
-   if (r.Read(m_accessCnt)) m_accessCnt = 0; // was: return false;
+   if (r.Read(m_accessCnt))  return false;
    TRACE(Dump, trace_pfx << " complete "<< m_complete << " access_cnt " << m_accessCnt);
 
    return true;

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -138,6 +138,11 @@ void Info::SetFileSize(long long fs)
 
 void Info::ResizeBits(int s)
 {
+    // drop buffer in case of failed/partial reads
+   if (m_buff_fetched)      free(m_buff_fetched);
+   if (m_buff_write_called) free(m_buff_write_called);
+   if (m_buff_prefetch)     free(m_buff_prefetch);
+
    m_sizeInBits = s;
    m_buff_fetched      = (unsigned char*) malloc(GetSizeInBytes());
    m_buff_write_called = (unsigned char*) malloc(GetSizeInBytes());

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -109,6 +109,11 @@ namespace XrdFileCache
          //---------------------------------------------------------------------
          bool WriteHeader(XrdOssDF* fp, const std::string &fname="<unknown>");
 
+          //---------------------------------------------------------------------
+         //! Disable allocating, writing, and reading of downlaod status
+         //---------------------------------------------------------------------
+         void DisableDownloadStatus();
+
          //---------------------------------------------------------------------
          //! Append access time, and cache statistics
          //! @return true on success

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -250,7 +250,10 @@ namespace XrdFileCache
 
    inline int Info::GetSizeInBytes() const
    {
-      return ((m_sizeInBits - 1)/8 + 1);
+       if (m_sizeInBits)
+           return ((m_sizeInBits - 1)/8 + 1);
+       else
+           return 0;
    }
 
    inline int Info::GetSizeInBits() const

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -109,19 +109,19 @@ void Print::printFile(const std::string& path)
            }
            printf("\n");
        }
-
-       int n_da = 0;
-       { int x = cfi.GetAccessCnt(); while (x) { x /= 10; ++n_da; } }
-       for (int i = 0; i < cfi.GetAccessCnt(); ++i)
-       {
-           printf("access %*d: ", n_da, i);
-           Info::AStat& a = statv[i];
-           char s[1000];
-           struct tm * p = localtime(&a.DetachTime);
-           strftime(s, 1000, "%c", p);
-           printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", s, a.BytesDisk, a.BytesRam, a.BytesMissed);
-       }
    }
+   int n_da = 0;
+   { int x = cfi.GetAccessCnt(); while (x) { x /= 10; ++n_da; } }
+   for (int i = 0; i < cfi.GetAccessCnt(); ++i)
+   {
+       printf("access %*d: ", n_da, i);
+       Info::AStat& a = statv[i];
+       char s[1000];
+       struct tm * p = localtime(&a.DetachTime);
+       strftime(s, 1000, "%c", p);
+       printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", s, a.BytesDisk, a.BytesRam, a.BytesMissed);
+   }
+   
    delete fh;
    printf("\n");
 }

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -80,42 +80,48 @@ void Print::printFile(const std::string& path)
       statv.push_back(a);
    }
 
-   int cntd = 0;
-   for (int i = 0; i < cfi.GetSizeInBits(); ++i) if (cfi.TestBit(i)) cntd++;
-
-   printf("version == %d, fileSize %lld, bufferSize %lld nBlocks %d nDownloaded %d %s\n",
-          cfi.GetVersion(), cfi.GetFileSize(),cfi.GetBufferSize(), cfi.GetSizeInBits(), cntd,
-          (cfi.GetSizeInBits() == cntd) ? "complete" : "");
-
-   if (m_verbose)
-   {
-      int n_db = 0;
-      { int x = cfi.GetSizeInBits(); while (x) { x /= 10; ++n_db; } }
-      static const char *nums = "0123456789";
-      printf("printing %d blocks:\n", cfi.GetSizeInBits());
-      printf("%*s  %10d%10d%10d%10d%10d%10d\n", n_db, "", 1, 2, 3, 4, 5, 6);
-      printf("%*s %s%s%s%s%s%s0123", n_db, "", nums, nums, nums, nums, nums, nums);
-      for (int i = 0; i < cfi.GetSizeInBits(); ++i)
-      {
-         if (i % 64 == 0)
-            printf("\n%*d ", n_db, i);
-         printf("%c", cfi.TestBit(i) ? 'x' : '.');
-      }
-      printf("\n");
+   if (cfi.GetVersion() < 0) {
+        // Top level info file for file block mode
+        printf("version == %d, fileSize %lld, bufferSize %lld \n",
+               abs(cfi.GetVersion()), cfi.GetFileSize(),cfi.GetBufferSize());
    }
+   else {
+       int cntd = 0;
+       for (int i = 0; i < cfi.GetSizeInBits(); ++i) if (cfi.TestBit(i)) cntd++;
 
-   int n_da = 0;
-   { int x = cfi.GetAccessCnt(); while (x) { x /= 10; ++n_da; } }
-   for (int i = 0; i < cfi.GetAccessCnt(); ++i)
-   {
-      printf("access %*d: ", n_da, i);
-      Info::AStat& a = statv[i];
-      char s[1000];
-      struct tm * p = localtime(&a.DetachTime);
-      strftime(s, 1000, "%c", p);
-      printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", s, a.BytesDisk, a.BytesRam, a.BytesMissed);
+       printf("version == %d, fileSize %lld, bufferSize %lld nBlocks %d nDownloaded %d %s\n",
+              cfi.GetVersion(), cfi.GetFileSize(),cfi.GetBufferSize(), cfi.GetSizeInBits(), cntd,
+              (cfi.GetSizeInBits() == cntd) ? "complete" : "");
+
+       if (m_verbose)
+       {
+           int n_db = 0;
+           { int x = cfi.GetSizeInBits(); while (x) { x /= 10; ++n_db; } }
+           static const char *nums = "0123456789";
+           printf("printing %d blocks:\n", cfi.GetSizeInBits());
+           printf("%*s  %10d%10d%10d%10d%10d%10d\n", n_db, "", 1, 2, 3, 4, 5, 6);
+           printf("%*s %s%s%s%s%s%s0123", n_db, "", nums, nums, nums, nums, nums, nums);
+           for (int i = 0; i < cfi.GetSizeInBits(); ++i)
+           {
+               if (i % 64 == 0)
+                   printf("\n%*d ", n_db, i);
+               printf("%c", cfi.TestBit(i) ? 'x' : '.');
+           }
+           printf("\n");
+       }
+
+       int n_da = 0;
+       { int x = cfi.GetAccessCnt(); while (x) { x /= 10; ++n_da; } }
+       for (int i = 0; i < cfi.GetAccessCnt(); ++i)
+       {
+           printf("access %*d: ", n_da, i);
+           Info::AStat& a = statv[i];
+           char s[1000];
+           struct tm * p = localtime(&a.DetachTime);
+           strftime(s, 1000, "%c", p);
+           printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", s, a.BytesDisk, a.BytesRam, a.BytesMissed);
+       }
    }
-
    delete fh;
    printf("\n");
 }


### PR DESCRIPTION
- write access time in top level info file
- skip reading and writing of downloaded bit for top level info file 
- in xrdpfc_print skip printing of download status for this case
